### PR TITLE
Returned wrong branch's value

### DIFF
--- a/lib/trie/node.ex
+++ b/lib/trie/node.ex
@@ -65,7 +65,7 @@ defmodule MerklePatriciaTree.Trie.Node do
        elem, acc when is_binary(elem) ->
          try do
            ## Ensure that the branch's value is not decoded
-           if length(acc) < 17 do
+           if length(acc) != 16 do
              acc ++ [ExRLP.decode(elem)]
            else
              acc ++ [elem]

--- a/lib/trie/node.ex
+++ b/lib/trie/node.ex
@@ -64,7 +64,12 @@ defmodule MerklePatriciaTree.Trie.Node do
 
        elem, acc when is_binary(elem) ->
          try do
-           acc ++ [ExRLP.decode(elem)]
+           ## Ensure that the branch's value is not decoded
+           if length(acc) < 17 do
+             acc ++ [ExRLP.decode(elem)]
+           else
+             acc ++ [elem]
+           end
          rescue
            _ ->
              acc ++ [elem]


### PR DESCRIPTION
Removed rlp decoding on branch's value