### PR TITLE
CircleCi icon removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MerklePatriciaTree [![CircleCI](https://circleci.com/gh/exthereum/merkle_patricia_tree.svg?style=svg)](https://circleci.com/gh/exthereum/merkle_patricia_tree)
+# MerklePatriciaTree
 
 Elixir implementation of Ethereum's Merkle Patricia Tries.
 


### PR DESCRIPTION
We shouldn't include CircleCI tests results for Ethereum foundation repo. Also tests don't pass on this repo.