### PR TITLE
Add builder_test.exs and destroyer_test.exs

### DIFF
--- a/lib/trie.ex
+++ b/lib/trie.ex
@@ -97,7 +97,8 @@ defmodule MerklePatriciaTree.Trie do
       {:branch, branches} ->
         # branch node
         case Enum.at(branches, nibble) do
-          [] -> nil
+          # KEN: Why not detect <<>> here?  empty branch is constructed with <<>> in builder
+          [] -> nil 
           node_hash -> node_hash |> into(trie) |> do_get(rest)
         end
 
@@ -125,7 +126,7 @@ defmodule MerklePatriciaTree.Trie do
     # Only branch nodes can have values for a nil lookup
     case Node.decode_trie(trie) do
       {:branch, branches} -> List.last(branches)
-      {:leaf, [], v} -> v
+      {:leaf, [], v} -> v # KEN: violate to the comment above?
       _ -> nil
     end
   end

--- a/lib/trie/builder.ex
+++ b/lib/trie/builder.ex
@@ -85,27 +85,15 @@ defmodule MerklePatriciaTree.Trie.Builder do
       {:ext, matching_prefix, new_encoded_trie}
     else
       # TODO: Handle when we need to add an extension after this
-      # TODO: Standardize with below
-      first =
-        case old_tl do
-          # [] -> {16, {:encoded, old_value}} # TODO: Is this right?
-          [h | []] ->
-            {h, {:encoded, old_value}}
+      branches = trie_put_key({:ext, old_tl, old_value}, new_tl, new_value, trie)
+        |> Node.encode_node(trie)
 
-          [h | t] ->
-            ext_encoded = {:ext, t, old_value} |> Node.encode_node(trie)
-
-            {h, {:encoded, ext_encoded}}
-        end
-
-      branches = build_branch([first, {new_tl, new_value}], trie) |> Node.encode_node(trie)
       {:ext, matching_prefix, branches}
     end
   end
 
   # Merge into a ext with no matches (i.e. create a branch)
   defp trie_put_key({:ext, old_prefix, old_value}, new_prefix, new_value, trie) do
-    # TODO: Standardize with above
     first =
       case old_prefix do
         [h | []] ->

--- a/lib/trie/builder.ex
+++ b/lib/trie/builder.ex
@@ -109,6 +109,8 @@ defmodule MerklePatriciaTree.Trie.Builder do
     first =
       case old_prefix do
         [h | []] ->
+          # old_value is pointing to a branch node.
+          # The result is a branch node containing another branch node.
           {h, {:encoded, old_value}}
 
         [h | t] ->

--- a/lib/trie/destroyer.ex
+++ b/lib/trie/destroyer.ex
@@ -40,7 +40,7 @@ defmodule MerklePatriciaTree.Trie.Destroyer do
   defp trie_remove_key({:ext, ext_prefix, node_hash}, key_prefix, trie) do
     {_matching_prefix, ext_tl, remaining_tl} = ListHelper.overlap(ext_prefix, key_prefix)
 
-    unless length(ext_tl) == 0 do
+    unless Enum.empty?(ext_tl) do
       # Prefix doesn't match ext, do nothing.
       {:ext, ext_prefix, node_hash}
     else

--- a/lib/trie/storage.ex
+++ b/lib/trie/storage.ex
@@ -96,7 +96,7 @@ defmodule MerklePatriciaTree.Trie.Storage do
       # In put_node(rlp, trie) and when byte_size(encoded) < @max_rlp_len,
       # it's directly returning encoded value
       encoded when byte_size(encoded) < @max_rlp_len ->
-        encoded
+        ExRLP.decode(encoded)
       h ->
         # stored in db
         case DB.get(trie.db, h) do

--- a/lib/trie/storage.ex
+++ b/lib/trie/storage.ex
@@ -93,7 +93,10 @@ defmodule MerklePatriciaTree.Trie.Storage do
       # node was stored directly
       x when not is_binary(x) ->
         x
-
+      # In put_node(rlp, trie) and when byte_size(encoded) < @max_rlp_len,
+      # it's directly returning encoded value
+      encoded when byte_size(encoded) < @max_rlp_len ->
+        encoded
       h ->
         # stored in db
         case DB.get(trie.db, h) do

--- a/test/trie/builder_test.exs
+++ b/test/trie/builder_test.exs
@@ -72,11 +72,9 @@ defmodule MerklePatriciaTree.BuilderTest do
 
     [node_prefix_tl, node_value] = Trie.into(value_hash, two_leaf_trie)
       |> Storage.get_node()
-      |> ExRLP.decode()
 
     [node2_prefix_tl, node2_value] = Trie.into(value2_hash, two_leaf_trie)
       |> Storage.get_node()
-      |> ExRLP.decode()
 
     { hexprefix_tl1, true } = HexPrefix.decode(node_prefix_tl)
     { hexprefix_tl2, true } = HexPrefix.decode(node2_prefix_tl)
@@ -323,7 +321,7 @@ defmodule MerklePatriciaTree.BuilderTest do
     two_leaf_trie = node
       |> store_node(one_leaf_trie)
 
-    # Update prepared ext node with 1-nibble longer key
+    # Update prepared ext node with 3-nibble longer key
     longer_key = [1, 2, 5, 6, 7]
     value3 = "value3"
     updated_ext_node = Node.decode_trie(two_leaf_trie)

--- a/test/trie/builder_test.exs
+++ b/test/trie/builder_test.exs
@@ -1,0 +1,446 @@
+defmodule MerklePatriciaTree.BuilderTest do
+  use ExUnit.Case, async: true
+  doctest MerklePatriciaTree.Trie.Builder
+
+  alias MerklePatriciaTree.Trie
+  alias MerklePatriciaTree.Trie.Builder
+  alias MerklePatriciaTree.Trie.Node
+  alias MerklePatriciaTree.Trie.Helper
+  alias MerklePatriciaTree.ListHelper
+  alias MerklePatriciaTree.Trie.Storage
+  alias MerklePatriciaTree.DB.ETS
+
+  setup do
+    db = ETS.random_ets_db()
+    trie = Trie.new(db)
+
+    {:ok, %{trie: trie}}
+  end
+
+  defp store_node(node, trie) do
+    Node.encode_node(node, trie)
+      |> Trie.into(trie)
+      |> Trie.store
+  end
+
+  test "Put key into empty trie", %{trie: trie} do
+    key = [1, 2, 3]
+    value = "value"
+
+    node = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+
+    assert node == {:leaf, key, value}
+  end
+
+  test "Put key into trie with only leaf node with identical key", %{trie: trie} do
+    key = Helper.get_nibbles("key")
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    value2 = "value2"
+    node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key, value2, one_leaf_trie)
+
+    assert node == {:leaf, key, value2}
+  end
+  
+  test "Put key into trie with a leaf node sharing nothing", %{trie: trie} do
+    key = [1, 2, 3]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [2, 3, 4]
+    value2 = "value2"
+    branch_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:branch, branch_options} = branch_node
+    assert length(branch_options) == 17
+
+    value_hash = Enum.at(branch_options, Enum.at(key, 0))
+    value2_hash = Enum.at(branch_options, Enum.at(key2, 0))
+
+    two_leaf_trie = branch_node
+      |> store_node(one_leaf_trie)
+
+    [node_prefix_tl, node_value] = Trie.into(value_hash, two_leaf_trie)
+      |> Storage.get_node()
+      |> ExRLP.decode()
+
+    [node2_prefix_tl, node2_value] = Trie.into(value2_hash, two_leaf_trie)
+      |> Storage.get_node()
+      |> ExRLP.decode()
+
+    { hexprefix_tl1, true } = HexPrefix.decode(node_prefix_tl)
+    { hexprefix_tl2, true } = HexPrefix.decode(node2_prefix_tl)
+
+    assert hexprefix_tl1 == [2, 3]
+    assert node_value == "value"
+
+    assert hexprefix_tl2 == [3, 4]
+    assert node2_value == "value2"
+  end
+
+  test "Put key into trie containing a leaf node with longer key", %{trie: trie} do
+    key = Helper.get_nibbles("keys")
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = Helper.get_nibbles("ke")
+    value2 = "value2"
+
+    node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, branch_hash} = node
+    assert matching_prefix == key2
+
+    two_leaf_trie = node
+      |> store_node(one_leaf_trie)
+    branch_node = Trie.into(branch_hash, two_leaf_trie)
+      |> Storage.get_node()
+
+    assert length(branch_node) == 17
+    assert Enum.at(branch_node, 16) == value2
+
+    [hd | tl] = ListHelper.get_postfix(key, key2)
+    leaf_hash = Enum.at(branch_node, hd)
+    assert byte_size(leaf_hash) < 32
+
+    leaf_node = ExRLP.decode(leaf_hash)
+
+    {:leaf, leaf_prefix, leaf_value} = Trie.into(leaf_node, two_leaf_trie)
+      |> Node.decode_trie()
+
+    assert leaf_prefix == tl
+    assert leaf_value == value
+  end
+
+  test "Put key into trie containing a leaf node with shorter key", %{trie: trie} do
+    key = Helper.get_nibbles("ke")
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = Helper.get_nibbles("keys")
+    value2 = "value2"
+
+    node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, branch_hash} = node
+    assert matching_prefix == key
+
+    two_leaf_trie = node
+      |> store_node(one_leaf_trie)
+    branch_node = Trie.into(branch_hash, two_leaf_trie)
+      |> Storage.get_node()
+
+    assert length(branch_node) == 17
+    assert Enum.at(branch_node, 16) == value
+
+    [hd | tl] = ListHelper.get_postfix(key2, key)
+    leaf_hash = Enum.at(branch_node, hd)
+    assert byte_size(leaf_hash) < 32
+
+    leaf_node = ExRLP.decode(leaf_hash)
+
+    {:leaf, leaf_prefix, leaf_value} = Trie.into(leaf_node, two_leaf_trie)
+      |> Node.decode_trie()
+
+    assert leaf_prefix == tl
+    assert leaf_value == value2
+  end
+
+  test "Put key into trie with a leaf node sharing common prefix", %{trie: trie} do
+    key = [1, 2, 3, 4]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2, 5, 6]
+    value2 = "value2"
+
+    node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, branch_hash} = node
+    assert matching_prefix == [1, 2]
+
+    two_leaf_trie = node
+      |> store_node(one_leaf_trie)
+    branch_node = Trie.into(branch_hash, two_leaf_trie)
+      |> Storage.get_node()
+
+    assert length(branch_node) == 17
+
+    # First leaf
+    leaf_hash = Enum.at(branch_node, 3)
+    assert byte_size(leaf_hash) < 32
+
+    leaf_node = ExRLP.decode(leaf_hash)
+
+    {:leaf, leaf_prefix, leaf_value} = Trie.into(leaf_node, two_leaf_trie)
+      |> Node.decode_trie()
+
+    assert leaf_prefix == [4]
+    assert leaf_value == value
+
+    # Second leaf
+    leaf2_hash = Enum.at(branch_node, 5)
+    assert byte_size(leaf2_hash) < 32
+
+    leaf2_node = ExRLP.decode(leaf2_hash)
+
+    {:leaf, leaf2_prefix, leaf2_value} = Trie.into(leaf2_node, two_leaf_trie)
+      |> Node.decode_trie()
+
+    assert leaf2_prefix == [6]
+    assert leaf2_value == value2
+  end
+
+  test "Put key into trie containing a ext node with exact prefix", %{trie: trie} do
+    # Prepare trie
+    key = Helper.get_nibbles("ke")
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = Helper.get_nibbles("keys")
+    value2 = "value2"
+
+    node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, branch_hash} = node
+
+    two_leaf_trie = node
+      |> store_node(one_leaf_trie)
+
+    # Update prepared ext node with exact prefix
+    updated_value = "updated_value"
+    updated_ext_node = Node.decode_trie(two_leaf_trie)
+      |> Builder.put_key(key, updated_value, two_leaf_trie)
+
+    {:ext, updated_matching_prefix, updated_branch_hash} = updated_ext_node
+    assert updated_matching_prefix == matching_prefix
+    assert updated_branch_hash != branch_hash
+
+    # Check updated branch node
+    updated_two_leaf_trie = updated_ext_node
+      |> store_node(two_leaf_trie)
+    updated_branch_node = Trie.into(updated_branch_hash, updated_two_leaf_trie)
+      |> Storage.get_node()
+
+    assert length(updated_branch_node) == 17
+    assert Enum.at(updated_branch_node, 16) == updated_value
+  end
+
+  test "Put key into trie containing a ext node with 1-nibble shorter prefix", %{trie: trie} do
+    # Prepare trie
+    key = [1, 2]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2, 3, 4]
+    value2 = "value2"
+
+    node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, branch_hash} = node
+
+    two_leaf_trie = node
+      |> store_node(one_leaf_trie)
+
+    # Update prepared ext node with 1-nibble longer key
+    longer_key = [1, 2, 5]
+    value3 = "value3"
+    updated_ext_node = Node.decode_trie(two_leaf_trie)
+      |> Builder.put_key(longer_key, value3, two_leaf_trie)
+
+    {:ext, updated_matching_prefix, updated_branch_hash} = updated_ext_node
+    assert updated_matching_prefix == matching_prefix
+    assert updated_branch_hash != branch_hash
+
+    # Check updated branch node
+    three_leaf_trie = updated_ext_node
+      |> store_node(two_leaf_trie)
+    updated_branch_node = Trie.into(updated_branch_hash, three_leaf_trie)
+      |> Storage.get_node()
+
+    assert length(updated_branch_node) == 17
+
+    # New leaf
+    leaf3_hash = Enum.at(updated_branch_node, 5)
+    assert byte_size(leaf3_hash) < 32
+
+    leaf3_node = ExRLP.decode(leaf3_hash)
+
+    {:leaf, leaf3_prefix, leaf3_value} = Trie.into(leaf3_node, three_leaf_trie)
+      |> Node.decode_trie()
+
+    assert leaf3_prefix == []
+    assert leaf3_value == value3
+  end
+
+  test "Put key into trie containing a ext node with 3-nibble shorter prefix", %{trie: trie} do
+    # Prepare trie
+    key = [1, 2]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2, 3, 4]
+    value2 = "value2"
+
+    node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, branch_hash} = node
+
+    two_leaf_trie = node
+      |> store_node(one_leaf_trie)
+
+    # Update prepared ext node with 1-nibble longer key
+    longer_key = [1, 2, 5, 6, 7]
+    value3 = "value3"
+    updated_ext_node = Node.decode_trie(two_leaf_trie)
+      |> Builder.put_key(longer_key, value3, two_leaf_trie)
+
+    {:ext, updated_matching_prefix, updated_branch_hash} = updated_ext_node
+    assert updated_matching_prefix == matching_prefix
+    assert updated_branch_hash != branch_hash
+
+    # Check updated branch node
+    three_leaf_trie = updated_ext_node
+      |> store_node(two_leaf_trie)
+    updated_branch_node = Trie.into(updated_branch_hash, three_leaf_trie)
+      |> Storage.get_node()
+
+    assert length(updated_branch_node) == 17
+
+    # New leaf
+    leaf3_hash = Enum.at(updated_branch_node, 5)
+    assert byte_size(leaf3_hash) < 32
+
+    leaf3_node = ExRLP.decode(leaf3_hash)
+
+    {:leaf, leaf3_prefix, leaf3_value} = Trie.into(leaf3_node, three_leaf_trie)
+      |> Node.decode_trie()
+
+    assert leaf3_prefix == [6, 7]
+    assert leaf3_value == value3
+  end
+
+  test "Put no match key into trie containing an ext node with 1-nibble prefix", %{trie: trie} do
+    # Prepare trie
+    key = [1]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2]
+    value2 = "value2"
+
+    ext_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, _branch_hash} = ext_node
+    assert matching_prefix == key
+
+    two_leaf_trie = store_node(ext_node, one_leaf_trie)
+
+    # Update prepared ext node with key sharing nothing
+    # Produce a new branch node with a branch node directly under it
+    key3 = [5]
+    value3 = "value3"
+    old_ext_node = {:ext, _prefix, decoded_old_branch } = Node.decode_trie(two_leaf_trie)
+
+    new_branch_node = {:branch, branch_options} = Builder.put_key(old_ext_node, key3, value3, two_leaf_trie)
+
+    assert Enum.at(branch_options, 1) == decoded_old_branch
+
+    # New leaf
+    leaf3_hash = Enum.at(branch_options, 5)
+    assert byte_size(leaf3_hash) < 32
+
+    three_leaf_trie = store_node(new_branch_node, two_leaf_trie)
+    leaf3_node = ExRLP.decode(leaf3_hash)
+
+    {:leaf, leaf3_prefix, leaf3_value} = Trie.into(leaf3_node, three_leaf_trie)
+      |> Node.decode_trie()
+
+    assert leaf3_prefix == []
+    assert leaf3_value == value3
+  end
+
+  test "Put no match key into trie containing an ext node with 2-nibble prefix", %{trie: trie} do
+    # Prepare trie
+    key = [1, 2]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2, 3]
+    value2 = "value2"
+
+    ext_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, _branch_hash} = ext_node
+    assert matching_prefix == key
+
+    two_leaf_trie = store_node(ext_node, one_leaf_trie)
+
+    # Update prepared ext node with key sharing nothing
+    # Produce a new branch node with an ext node under it
+    key3 = [5, 6]
+    value3 = "value3"
+    old_ext_node = {:ext, _prefix, decoded_old_branch } = Node.decode_trie(two_leaf_trie)
+
+    new_branch_node = {:branch, branch_options} = Builder.put_key(old_ext_node, key3, value3, two_leaf_trie)
+    three_leaf_trie = store_node(new_branch_node, two_leaf_trie)
+
+    # New Ext
+    new_ext_hash = Enum.at(branch_options, 1)
+
+    {:ext, old_branch_prefix, old_branch_value} = Trie.into(new_ext_hash, three_leaf_trie)
+      |> Node.decode_trie()
+
+    assert old_branch_prefix == [2]
+    assert decoded_old_branch == old_branch_value
+
+    # New leaf
+    new_leaf_hash = Enum.at(branch_options, 5)
+    new_leaf_node = ExRLP.decode(new_leaf_hash)
+
+    assert byte_size(new_leaf_hash) < 32
+    assert new_leaf_node == ["6", value3]
+  end
+end

--- a/test/trie/destroyer_test.exs
+++ b/test/trie/destroyer_test.exs
@@ -1,0 +1,246 @@
+defmodule MerklePatriciaTree.DestroyerTest do
+  use ExUnit.Case, async: true
+  doctest MerklePatriciaTree.Trie.Destroyer
+
+  alias MerklePatriciaTree.Trie
+  alias MerklePatriciaTree.Trie.Builder
+  alias MerklePatriciaTree.Trie.Destroyer
+  alias MerklePatriciaTree.Trie.Node
+  alias MerklePatriciaTree.DB.ETS
+
+  setup do
+    db = ETS.random_ets_db()
+    trie = Trie.new(db)
+
+    {:ok, %{trie: trie}}
+  end
+
+  defp store_node(node, trie) do
+    Node.encode_node(node, trie)
+      |> Trie.into(trie)
+      |> Trie.store
+  end
+
+  test "Remove exact leaf from trie with only the leaf", %{trie: trie} do
+    key = [1, 2, 3]
+    value = "value"
+
+    node = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+
+    one_leaf_trie = store_node(node, trie)
+
+    after_removal = Destroyer.remove_key(node, key, one_leaf_trie)
+
+    assert after_removal == :empty
+  end
+
+  test "Remove non-existed key from trie with only a leaf", %{trie: trie} do
+    key = [1, 2, 3]
+    value = "value"
+
+    node = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+
+    one_leaf_trie = store_node(node, trie)
+
+    after_removal = Destroyer.remove_key(node, [4], one_leaf_trie)
+
+    assert after_removal == node
+  end
+
+  test "Remove key whose value is directly on branch", %{trie: trie} do
+    key = [1, 2, 3]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2]
+    value2 = "value2"
+    {:ext, _prefix, _branch_hash} = ext_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    two_leaf_trie = ext_node
+      |> store_node(one_leaf_trie)
+
+    after_removal = Destroyer.remove_key(ext_node, key2, two_leaf_trie)
+
+    assert after_removal == {:leaf, key, value}
+  end
+
+  test "Remove key whose value is beneath branch and leaving only one leaf", %{trie: trie} do
+    key = [1, 2, 3]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2]
+    value2 = "value2"
+    {:ext, _prefix, _branch_hash} = ext_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    two_leaf_trie = ext_node
+      |> store_node(one_leaf_trie)
+
+    after_removal = Destroyer.remove_key(ext_node, key, two_leaf_trie)
+
+    assert after_removal == {:leaf, key2, value2}
+  end
+
+  test "Remove key sharing nothing with the ext prefix", %{trie: trie} do
+    key = [1, 2, 3]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2]
+    value2 = "value2"
+    {:ext, _prefix, _branch_hash} = ext_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    two_leaf_trie = ext_node
+      |> store_node(one_leaf_trie)
+
+    after_removal = Destroyer.remove_key(ext_node, [3], two_leaf_trie)
+
+    assert after_removal == ext_node
+  end
+
+  test "Remove key from trie containing a ext node and branch with 3 nodes", %{trie: trie} do
+    # Prepare trie
+    key = [1, 2]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2, 3, 4]
+    value2 = "value2"
+
+    ext_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, _ext_prefix, _branch_hash} = ext_node
+
+    two_leaf_trie = ext_node
+      |> store_node(one_leaf_trie)
+
+    # Puts a new key which is removed later
+    key3 = [1, 2, 5]
+    value3 = "value3"
+    {:ext, _ext_prefix, _updated_branch_hash} = updated_ext_node = Node.decode_trie(two_leaf_trie)
+      |> Builder.put_key(key3, value3, two_leaf_trie)
+
+    three_leaf_trie = updated_ext_node
+      |> store_node(two_leaf_trie)
+
+    # Remove just put new key
+    after_removal_ext = Destroyer.remove_key(updated_ext_node, key3, three_leaf_trie)
+    assert after_removal_ext == ext_node
+  end
+
+  test "Remove key from a branch beneath a branch which produces an ext node", %{trie: trie} do
+    # Prepare trie
+    key = [1]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2]
+    value2 = "value2"
+
+    ext_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, _ext_prefix, _branch_hash} = ext_node
+
+    two_leaf_trie = store_node(ext_node, one_leaf_trie)
+
+    # Update prepared ext node with key sharing nothing
+    # Produce a new branch node with a branch node directly under it
+    key3 = [5]
+    value3 = "value3"
+    old_ext_node = {:ext, _prefix, decoded_old_branch } = Node.decode_trie(two_leaf_trie)
+
+    new_branch_node = {:branch, _branch_options} = Builder.put_key(old_ext_node, key3, value3, two_leaf_trie)
+    three_leaf_trie = store_node(new_branch_node, two_leaf_trie)
+
+    # Remove newly added key produce an ext node with original branch node
+    after_removal_ext = Destroyer.remove_key(new_branch_node, key3, three_leaf_trie)
+    assert after_removal_ext == {:ext, key, decoded_old_branch}
+  end
+
+  test "Remove key from a branch percolating up the ext node beneath it", %{trie: trie} do
+    # Prepare trie
+    key = [1, 2]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2, 3]
+    value2 = "value2"
+
+    ext_node = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+
+    {:ext, matching_prefix, _branch_hash} = ext_node
+    assert matching_prefix == key
+
+    two_leaf_trie = store_node(ext_node, one_leaf_trie)
+
+    # Update prepared ext node with key sharing nothing
+    # Produce a new branch node with an ext node under it
+    key3 = [5, 6]
+    value3 = "value3"
+    old_ext_node = {:ext, _prefix, _decoded_old_branch } = Node.decode_trie(two_leaf_trie)
+
+    new_branch_node = {:branch, _branch_options} = Builder.put_key(old_ext_node, key3, value3, two_leaf_trie)
+    three_leaf_trie = store_node(new_branch_node, two_leaf_trie)
+
+    # Remove newly added key produce an ext node with original branch node
+    after_removal_ext = Destroyer.remove_key(new_branch_node, key3, three_leaf_trie)
+    assert after_removal_ext == old_ext_node
+  end
+
+  test "Remove key from an ext percolating up the ext node beneath it", %{trie: trie} do
+    # Prepare trie
+    key = [1, 2]
+    value = "value"
+
+    one_leaf_trie = Node.decode_trie(trie)
+      |> Builder.put_key(key, value, trie)
+      |> store_node(trie)
+
+    key2 = [1, 2, 3, 4, 5]
+    value2 = "value2"
+
+    two_leaf_trie = Node.decode_trie(one_leaf_trie)
+      |> Builder.put_key(key2, value2, one_leaf_trie)
+      |> store_node(one_leaf_trie)
+
+    key3 = [1, 2, 3, 4, 6]
+    value3 = "value3"
+    ext_node = Node.decode_trie(two_leaf_trie)
+      |> Builder.put_key(key3, value3, two_leaf_trie)
+    three_leaf_trie = store_node(ext_node, two_leaf_trie)
+
+    # Remove key of the branch percolating up the ext node beneath it
+    {:ext, new_ext_prefix, new_branch_hash} = Destroyer.remove_key(ext_node, key, three_leaf_trie)
+    assert new_ext_prefix == [1, 2, 3, 4]
+    assert {:leaf, [], value2} == ExRLP.decode(Enum.at(new_branch_hash, 5))
+      |> Node.decode_node(two_leaf_trie)
+    assert {:leaf, [], value3} == ExRLP.decode(Enum.at(new_branch_hash, 6))
+      |> Node.decode_node(two_leaf_trie)
+  end
+end


### PR DESCRIPTION
Hi,

The interest of learning Elixir and blockchain brought me into reading the source of aeternity and this repository.
And I am trying to add a unit test for lib/trie/builder.exs in order to understand it more.

There are potentially some issues I caught when writing the test.
I wrote some comments there too.

1. In trie.ex, why nil detection is on `[]` instead of `<<>>`, in builder.exs, it's using `<<>>` to build empty branch?  and `<<>>` will ultimately lead to `nil` value as well.
2. In node.ex, it's assuming the ext node's value must be stored in DB.  While during testing, it seems sometimes it's just encoded branch value
3. In storage.ex, `get_node` returns `:not_found` when `byte_size(encoded) < @max_rlp_len`, it seems inconsistent with `put_node`.  Should it return the encoded value instead?

Hope this is PR is not rude and some of my question can be clarified.
Thanks.